### PR TITLE
Change LIMC host and URL

### DIFF
--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -158,8 +158,10 @@ UsePhp: true
 # limc
 
 [080E]
-Host: data.dasch.swiss
 UsePhp: true
+Host: weblimc.org
+PhpResourceRedirectUrl: http://$host/monument/$resource_int_id
+PhpResourceVersionRedirectUrl: http://$host/monument/$resource_int_id?citdate=$timestamp
 AllowVersion0: true
 
 

--- a/tests/test_080E.tavern.yaml
+++ b/tests/test_080E.tavern.yaml
@@ -15,4 +15,4 @@ stages:
     response:
       status_code: 302
       headers:
-        location: http://data.dasch.swiss/resources/2126045?citdate=20190129
+        location: http://weblimc.org/monument/2126045?citdate=20190129


### PR DESCRIPTION
This makes LIMC requests go to `http://weblimc.org/monument/`, per their request (the previous ARK resolver script had a special case for this).