### PR TITLE
A timestamp should be ignored if it's too short

### DIFF
--- a/tests/test_080E.tavern.yaml
+++ b/tests/test_080E.tavern.yaml
@@ -15,4 +15,4 @@ stages:
     response:
       status_code: 302
       headers:
-        location: http://weblimc.org/monument/2126045?citdate=20190129
+        location: http://weblimc.org/monument/2126045


### PR DESCRIPTION
If a PHP-SALSAH timestamp is shorter than 8 characters (YYYYMMDD), it could be ambiguous, so I think we should ignore it as per https://github.com/dhlab-basel/ark-resolver/commit/3120dc06264cdda502b5db4bd81ff4f05322f3bf.