### PR TITLE
fix: Fix project codes

### DIFF
--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -205,10 +205,6 @@ UsePhp: true
 Host: data.dasch.swiss
 UsePhp: true
 
-[080E]
-Host: data.dasch.swiss
-UsePhp: true
-
 [0811]
 Host: data.dasch.swiss
 UsePhp: true

--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -145,10 +145,11 @@ Host: 0.0.0.0:3333
 
 
 ############################################################################
-# lhtt
+# webern
 
 [0806]
-Host: 0.0.0.0:3333
+Host: data.dasch.swiss
+UsePhp: true
 
 
 ############################################################################
@@ -204,15 +205,7 @@ UsePhp: true
 Host: data.dasch.swiss
 UsePhp: true
 
-[080D]
-Host: data.dasch.swiss
-UsePhp: true
-
-[080F]
-Host: data.dasch.swiss
-UsePhp: true
-
-[0810]
+[080E]
 Host: data.dasch.swiss
 UsePhp: true
 
@@ -227,7 +220,6 @@ UsePhp: true
 Host: data.dasch.swiss
 UsePhp: true
 AllowVersion0: true
-
 
 [0813]
 Host: data.dasch.swiss
@@ -281,9 +273,11 @@ UsePhp: true
 Host: data.dasch.swiss
 UsePhp: true
 
+############################################################################
+# lhtt
+
 [0820]
-Host: data.dasch.swiss
-UsePhp: true
+Host: 0.0.0.0:3333
 
 [0821]
 Host: data.dasch.swiss
@@ -311,11 +305,3 @@ UsePhp: true
 
 [0826]
 Host: 0.0.0.0:3333
-
-
-############################################################################
-# webern
-
-[08AE]
-Host: data.dasch.swiss
-UsePhp: true

--- a/data/shortcodes.csv
+++ b/data/shortcodes.csv
@@ -25,38 +25,35 @@ Basel range - 0800 to 08FF,,,
 0803,incunabula,Bilderfolgen Basler Frühdrucke,3
 0804,dokubib,Bilddatenbank Bibliothek St. Moritz,8
 0805,ubkvp,University of Basel Kings Valley Project,
-0806,lhtt,Living Histories of Theban Tombs,
+0806,webern,Anton Webern Gesamtausgabe,6
 0807,mls,Musikalisches Lexikon der Schweiz,
 0808,terlag,Lager des Territorialdienstes 1942-1945,
-,lager,Lager des Territorialdienstes 1942-1945,35
-0809,ecodices,e-codices,2
-080A,pharch,Photo Archive,7
-080B,gast,Gast,9
-080C,SGV_oldproject,alte Bilddatenbank SGV,10
-080D,sgv,Bilddatenbank der Schweizerischen Gesellschaft für Volkskunde,18
+0809,ecodices,e-codices,
+080A,pharch,Photo Archive,
+080B,gast,Gast,
+080C,kuhaba,Fotosammlung der Kunsthalle Basel,12
+080D,sgv-film,Filmdatenbank der Schweizerischen Gesellschaft für Volkskunde,
 080E,LIMC,Lexicon Iconographicum Mythlogiae Classicae,14
-080F,kuhaba,Fotosammlung der Kunsthalle Basel,12
-0810,DaSCH,Data and Service Center for the Humanities,13
-0811,digi-archives,Digi-Archives Saint-Maurice,30
-0812,elib,e-lib.ch,15
-0813,heidelberg,heidelberg,16
-0814,postcards,Postkarten Russland,17
-0815,BMF,Bruno Manser Fonds,19
-0816,wackernagel,Rudolf Wackernagel,20
-0817,travis,trAVis,21
-0818,vitrails,Inventaires des vitraux,22
-0819,Parzival,Parzival,23
-081A,bosnienfoto,Kriegsfotografie aus Bosnien 1992-1995,24
-081B,dhlab-web,Digital Humanities Lab,25
-081C,smp,SALSAH Movie Player,26
-081D,delille,Reconstruire Delille,27
-081E,HdM,Hôtel de Musique Bern,28
-081F,RTI,TestRTIProj,29
-0820,litfeuilleton,Das Literarische Feuilleton,31
-0821,kindia,Kinetische Dias,32
-0822,TEST,TEST,33
-0823,rel-lu,Religionsvielfalt im Kanton Luzern,34
-0824,sgv-film,Filmdatenbank der Schweizerischen Gesellschaft für Volkskunde,36
-0825,s3r,Stiftsbliothek St. Gallen,25
-0826,wordweb,WordWeb
-08AE,webern,Anton Webern Gesamtausgabe,6
+080F,elib,e-lib.ch,
+0810,DaSCH,Data and Service Center for the Humanities,
+0811,postcards,Postkarten Russland,17
+0812,sgv,Bilddatenbank der Schweizerischen Gesellschaft für Volkskunde,18
+0813,BMF,Bruno Manser Fonds,19
+0814,wackernagel,Rudolf Wackernagel,20
+0815,TEST,TEST,
+0816,vitrails,Inventaires des vitraux,22
+0817,Parzival,Parzival,23
+0818,bosnienfoto,Kriegsfotografie aus Bosnien 1992-1995,24
+0819,RTI,TestRTIProj,
+081A,smp,SALSAH Movie Player,
+081B,delille,Reconstruire Delille,27
+081C,HdM,Hôtel de Musique Bern,28
+081D,travis,trAVis,
+081E,dhlab-web,Digital Humanities Lab,
+081F,litfeuilleton,Das Literarische Feuilleton,31
+0820,lhtt,Living Histories of Theban Tombs,
+0821,kindia,Kinetische Dias,
+0822,rel-lu,Religionsvielfalt im Kanton Luzern,
+0823,heidelberg,heidelberg,
+0825,s3r,Stiftsbliothek St. Gallen,
+0826,wordweb,WordWeb,


### PR DESCRIPTION
This PR fixes some project codes so they correspond to the ones exported from PHP SALSAH. Since this produces some conflicting project codes, some others have to be changed as well.

@lrosenth sent me this list of all projects in PHP SALSAH:

|Shortcode|Shortname|Decimal ID in PHP SALSAH|
|------|---|---|
|0803|incunabula|3|
|0806|webern|6|
|0808|dokubib|8|
|080C|kuhaba|12|
|080E|LIMC|14|
|0811|postcards|17|
|0812|SGV|18|
|0813|BMF|19|
|0814|wackernagel|20|
|0816|vitrails|22|
|0817|Parzival|23|
|0818|bosnienfoto|24|
|081B|delille|27|
|081C|HdM|28|
|081F|litfeuilleton|31|

Most of these codes conflicted with codes assigned in `shortcodes.csv`. In all but one case, I changed the code of the other project, as follows:

* `0806` (`lhtt` -> `webern`, `lhtt` got `0820`) 
* `080C` (`SGV_oldproject` -> `kuhaba`, I deleted `SGV_oldproject` because it is apparently not needed)
* `0811` (`digi-archives` -> `postcards`, I deleted `digi-archives` because Lukas said to do so)
* `0812` (`elib` -> `SGV`, `elib` got `080F`)
* `0813` (`heidelberg` -> `BMF`, `heidelberg` got `0823`)
* `0814` (`postcards` -> `wackernagel`, `postcards` got `0811`)
* `0816` (`wackernagel` -> `vitralis`, `wackernagel` got `0814`)
* `0817` (`travis` -> `Parzival`, `travis` got `081D`)
* `0818` (`vitralis` -> `bosnienfoto`, `vitralis` got `0816`)
* `081B` (`dhlab-web` -> `delille`, `dhlab-web` got `081E`)
* `081C` (`smp` -> `HdM`, `smp` got `081A`)
* `081F` (`RTI` -> `litfeuilleton`, `RTI` got `0819`)

The exception is `0808`, where there was a  conflict between `dokubib` and `terlag`. In the Knora test data, `dokubib` is `0804`. Lukas said it would be better to reassign `dokubib` than `terlag`, so I changed `dokubib` to `0804` in `shortcodes.csv`, so we don't have to change the Knora test data.

I also removed the values of `OLD SALSAH ID` from `shortcodes.csv` for projects that are not in the above list.

As far as I understand, if a project is not in PHP SALSAH (i.e. not in the above list) and is not live in Knora (i.e. not BEOL) its project code can be changed. So I changed some other project codes to remove gaps between codes. I made exceptions for `0825` and `0826`, because they have entries in `dasch_ark_registry.ini`.

In `dasch_ark_registry.ini`, I removed entries with `UsePhp: true` that don't correspond to any project in the above list. I made an exception for `0825`, because it looks like it's supposed to be live on `app.langzeitarchivierung.ch` (although that site is down).

Does this make sense?